### PR TITLE
rm type assertion in ValidateFunc & rm golint warning

### DIFF
--- a/linter/analyzer.go
+++ b/linter/analyzer.go
@@ -34,7 +34,7 @@ func (a Analyzer) Run(node *parser.Node) ([]string, error) {
 
 	for _, rule := range a.rules {
 		go func(r *rules.Rule) {
-			vrst, err := r.ValidateFunc.(func(*parser.Node) ([]rules.ValidateResult, error))(node)
+			vrst, err := r.ValidateFunc(node)
 			if err != nil {
 				errChan <- err
 			} else {

--- a/linter/rules/dl3021.go
+++ b/linter/rules/dl3021.go
@@ -27,7 +27,7 @@ func isDL3021Error(node *parser.Node) bool {
 			}
 			return false
 		default:
-			c += 1
+			c++
 			return fn(nd.Next, nd.Value)
 		}
 	}

--- a/linter/rules/rule.go
+++ b/linter/rules/rule.go
@@ -3,6 +3,8 @@ package rules
 
 import (
 	"fmt"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
 )
 
 // Rule is filtered rule (with ignore rule applied)
@@ -11,7 +13,7 @@ type Rule struct {
 	Code         string
 	Severity     Severity
 	Description  string
-	ValidateFunc interface{}
+	ValidateFunc func(node *parser.Node) (rst []ValidateResult, err error)
 }
 
 // ValidateResult ValidateFunc's results


### PR DESCRIPTION
全てのValidateFuncが同じ形だった為、型アサーションが不要だと思い削除してみました。

これでパフォーマンスの問題以外に、パッケージとして使用したいユーザーにとって、どのような関数をvalidateFuncとして渡すべきかが分かりやすくなると思います。

またgolintでwarningが出ている箇所を削除しました。

ご検討宜しくお願いします！