### PR TITLE
Trigger CI build on pull requests

### DIFF
--- a/.github/workflows/go118.yml
+++ b/.github/workflows/go118.yml
@@ -1,5 +1,11 @@
 name: go1.18
-on: [push]
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
 jobs:
 
   build:


### PR DESCRIPTION
I realized that this repo doesn't trigger CI builds on creating pull requests. That's helpful for contributors to understand they need to work if CI fails, and the maintainer doesn't have to manually check whether (1) changed code builds and (2) tests pass.