### PR TITLE
delete archive method from goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,16 +16,3 @@ builds:
     main: .
     ldflags: -s -w -X main.Version={{.Version}}  -X main.BuildDate={{.Date}}
     binary: godolint
-archive:
-  format: tar.gz
-  name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{
-    .Arm }}{{ end }}'
-  files:
-    - licence*
-    - LICENCE*
-    - license*
-    - LICENSE*
-    - readme*
-    - README*
-    - changelog*
-    - CHANGELOG*


### PR DESCRIPTION
```
➜ goreleaser 
  • starting release...
  ⨯ release failed after 0s                  error=yaml: unmarshal errors:
  line 19: field archive not found in type config.Project


```