### PR TITLE
refactor: modernize Go code with Go 1.21+ features

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,13 +25,15 @@ guidelines you need to follow.
      project already has good test coverage, so look at some of the existing
      tests if you're unsure how to go about it.
 
-  5. Do your best to have [well-formed commit messages][] for each change.
-     This provides consistency throughout the project, and ensures that commit
-     messages are able to be formatted properly by various git tools.
+  5. Do your best to have well-formed commit messages for each change.
+     This project follows [Conventional Commits](https://www.conventionalcommits.org/).
+     Examples:
+     - `feat: add new rule DL3028`
+     - `fix: correct port validation in DL3011`
+     - `docs: update installation guide`
+     - `refactor: simplify analyzer logic`
 
   6. Finally, push the commits to your fork and submit a [pull request][].
 
 [forking]: https://help.github.com/articles/fork-a-repo
-[well-formed commit messages]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
-[squash]: http://git-scm.com/book/en/Git-Tools-Rewriting-History#Squashing-Commits
 [pull request]: https://help.github.com/articles/creating-a-pull-request

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 godolint
 ===
 
-[![GitHub release](http://img.shields.io/github/release/zabio3/godolint.svg?style=flat-square)](https://github.com/zabio3/godolint/releases/latest)
-[![Actions Status](https://github.com/zabio3/godolint/workflows/go1.22/badge.svg)](https://github.com/zabio3/godolint/actions)
-[![Golang CI](https://golangci.com/badges/github.com/zabio3/godolint.svg)](https://golangci.com/r/github.com/zabio3/godolint)
+[![GitHub release](https://img.shields.io/github/release/zabio3/godolint.svg?style=flat-square)](https://github.com/zabio3/godolint/releases/latest)
+[![CI](https://github.com/zabio3/godolint/workflows/CI/badge.svg)](https://github.com/zabio3/godolint/actions)
 [![Go Report Card](https://goreportcard.com/badge/github.com/zabio3/godolint)](https://goreportcard.com/report/github.com/zabio3/godolint)
-[![GoDoc](https://godoc.org/github.com/zabio3/godolint?status.svg)](https://godoc.org/github.com/zabio3/godolint)
-[![Maintainability](https://api.codeclimate.com/v1/badges/4c1c216781e5592d4194/maintainability)](https://codeclimate.com/github/zabio3/godolint/maintainability)
-[![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
+[![Go Reference](https://pkg.go.dev/badge/github.com/zabio3/godolint.svg)](https://pkg.go.dev/github.com/zabio3/godolint)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 
 A Dockerfile linter that helps you build [best practice](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) Docker images (inspired by [Haskell Dockerfile Linter](https://github.com/hadolint/hadolint)).
 This tool performs docker rule checks based on an abstract syntax tree (AST) of a Dockerfile where the AST is generated using [moby/buildkit parser](https://github.com/moby/buildkit/tree/master/frontend/dockerfile/parser).
@@ -67,10 +65,10 @@ $ godolint --ignore DL3000 testdata/DL3000_Dockerfile
 
 You can download a binary from the release page and place it in `$PATH` directory.
 
-Or you can use `go get`:
+Or you can use `go install`:
 
 ```
-$ go get github.com/zabio3/godolint
+$ go install github.com/zabio3/godolint@latest
 ```
 
 ## Rules
@@ -122,7 +120,7 @@ For the definitions of the AST, see [moby/buildkit](https://github.com/moby/buil
 Contributions are of course always welcome!
 
 1. Fork zabio3/godolint (https://github.com/zabio3/godolint/fork)
-2. Run `go get` to install dependencies
+2. Run `go mod download` to install dependencies
 3. Create a feature branch
 4. Commit your changes
 5. Run test using `go test ./...`

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 	"sort"
 	"strings"
 
@@ -14,10 +15,18 @@ import (
 	"github.com/zabio3/godolint/linter"
 )
 
-const (
-	name    = "godolint"
-	version = "1.0.3"
-)
+const name = "godolint"
+
+// getVersion returns the version from build info, or "dev" if not available.
+func getVersion() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		v := info.Main.Version
+		if v != "" && v != "(devel)" {
+			return v
+		}
+	}
+	return "dev"
+}
 
 // Exit codes are int values that represent an exit code for a particular error.
 const (
@@ -82,7 +91,7 @@ func (cli *CLI) Run(args []string) int {
 	}
 
 	if isVersion {
-		fmt.Fprintf(cli.OutStream, "godolint version %v\n", version)
+		fmt.Fprintf(cli.OutStream, "godolint version %s\n", getVersion())
 		return ExitCodeOK
 	}
 

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -7,10 +7,16 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
 	"github.com/zabio3/godolint/linter"
+)
+
+const (
+	name    = "godolint"
+	version = "1.0.3"
 )
 
 // Exit codes are int values that represent an exit code for a particular error.
@@ -22,10 +28,6 @@ const (
 	ExitCodeAstParseError
 	ExitCodeLintCheckError
 )
-
-const name = "godolint"
-
-const version = "1.0.3"
 
 const usage = `godolint - Dockerfile linter written in Golang
 
@@ -50,7 +52,7 @@ type CLI struct {
 type sliceString []string
 
 func (ss *sliceString) String() string {
-	return fmt.Sprintf("%s", *ss)
+	return strings.Join(*ss, ",")
 }
 
 func (ss *sliceString) Set(value string) error {
@@ -97,6 +99,7 @@ func (cli *CLI) Run(args []string) int {
 		fmt.Fprint(cli.ErrStream, err)
 		return ExitCodeFileError
 	}
+	defer f.Close()
 
 	r, err := parser.Parse(f)
 	if err != nil {
@@ -111,12 +114,7 @@ func (cli *CLI) Run(args []string) int {
 		return ExitCodeLintCheckError
 	}
 
-	rst = sort.StringSlice(rst)
-	var output string
-	for i := range rst {
-		// ends of each strings have "\n"
-		output = output + rst[i]
-	}
-	fmt.Fprint(cli.OutStream, output)
+	sort.Strings(rst)
+	fmt.Fprint(cli.OutStream, strings.Join(rst, ""))
 	return ExitCodeOK
 }

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -40,7 +40,7 @@ Available options:
 		},
 		{
 			command:           "godolint --version",
-			expectedOutStream: "godolint version 1.0.3\n",
+			expectedOutStream: "godolint version dev\n",
 			expectedErrStream: "",
 			expectedExitCode:  ExitCodeOK,
 		},

--- a/linter/analyzer_test.go
+++ b/linter/analyzer_test.go
@@ -1,6 +1,7 @@
 package linter
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
@@ -8,12 +9,14 @@ import (
 
 func TestAnalyzer(t *testing.T) {
 	cases := []struct {
+		name        string
 		node        *parser.Node
 		ignoreRules []string
 		expectedRst []string
 		expectedErr error
 	}{
 		{
+			name: "relative WORKDIR violation",
 			node: &parser.Node{
 				Value: "",
 				Next:  (*parser.Node)(nil),
@@ -127,6 +130,7 @@ func TestAnalyzer(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			name: "all rules ignored",
 			node: nil,
 			ignoreRules: []string{
 				"DL3000",
@@ -167,196 +171,17 @@ func TestAnalyzer(t *testing.T) {
 		},
 	}
 
-	for i, tc := range cases {
-		analyzer := NewAnalyzer(tc.ignoreRules, nil)
-		gotRst, gotErr := analyzer.Run(tc.node)
-		if !sliceEq(tc.expectedRst, gotRst) {
-			t.Errorf("#%d results deep equal has returned: want %s, got %s", i, tc.expectedRst, gotRst)
-		}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			analyzer := NewAnalyzer(tc.ignoreRules, nil)
+			gotRst, gotErr := analyzer.Run(tc.node)
+			if !slices.Equal(tc.expectedRst, gotRst) {
+				t.Errorf("results deep equal has returned: want %s, got %s", tc.expectedRst, gotRst)
+			}
 
-		if gotErr != tc.expectedErr {
-			t.Errorf("#%d Unexpected outStream has returned: want: %s, got: %s", i, tc.expectedErr, gotErr)
-		}
-
-		cleanup(t)
+			if gotErr != tc.expectedErr {
+				t.Errorf("unexpected outStream has returned: want: %s, got: %s", tc.expectedErr, gotErr)
+			}
+		})
 	}
-
-}
-
-func TestGetMakeDifference(t *testing.T) {
-	cases := []struct {
-		ignoreRules []string
-		rules       []string
-		expectedRst []string
-	}{
-		{
-			ignoreRules: []string{
-				"DL3001",
-				"DL3018",
-				"DL4004",
-			},
-			rules: []string{
-				"DL3000",
-				"DL3001",
-				"DL3002",
-				"DL3003",
-				"DL3004",
-				"DL3005",
-				"DL3006",
-				"DL3007",
-				"DL3008",
-				"DL3009",
-				"DL3010",
-				"DL3011",
-				//"DL3012",
-				"DL3013",
-				"DL3014",
-				"DL3015",
-				"DL3016",
-				"DL3018",
-				"DL3019",
-				"DL3020",
-				"DL3021",
-				"DL3022",
-				"DL3023",
-				"DL3024",
-				"DL3025",
-				"DL4000",
-				"DL4001",
-				"DL4003",
-				"DL4004",
-				"DL4005",
-				"DL4006",
-			},
-			expectedRst: []string{
-				"DL3000",
-				"DL3002",
-				"DL3003",
-				"DL3004",
-				"DL3005",
-				"DL3006",
-				"DL3007",
-				"DL3008",
-				"DL3009",
-				"DL3010",
-				"DL3011",
-				//"DL3012",
-				"DL3013",
-				"DL3014",
-				"DL3015",
-				"DL3016",
-				"DL3019",
-				"DL3020",
-				"DL3021",
-				"DL3022",
-				"DL3023",
-				"DL3024",
-				"DL3025",
-				"DL4000",
-				"DL4001",
-				"DL4003",
-				"DL4005",
-				"DL4006",
-			},
-		},
-		{
-			ignoreRules: []string{
-				"DL3000",
-				"DL3001",
-				"DL3002",
-				"DL3003",
-				"DL3004",
-				"DL3005",
-				"DL3006",
-				"DL3007",
-				"DL3008",
-				"DL3009",
-				"DL3010",
-				"DL3011",
-				//"DL3012",
-				"DL3013",
-				"DL3014",
-				"DL3015",
-				"DL3016",
-				"DL3018",
-				"DL3019",
-				"DL3020",
-				"DL3021",
-				"DL3022",
-				"DL3023",
-				"DL3024",
-				"DL3025",
-				"DL4000",
-				"DL4001",
-				"DL4003",
-				"DL4004",
-				"DL4005",
-				"DL4006",
-			},
-			rules: []string{
-				"DL3001",
-				"DL3018",
-				"DL4004",
-			},
-			expectedRst: []string{
-				"DL3000",
-				"DL3002",
-				"DL3003",
-				"DL3004",
-				"DL3005",
-				"DL3006",
-				"DL3007",
-				"DL3008",
-				"DL3009",
-				"DL3010",
-				"DL3011",
-				//"DL3012",
-				"DL3013",
-				"DL3014",
-				"DL3015",
-				"DL3016",
-				"DL3019",
-				"DL3020",
-				"DL3021",
-				"DL3022",
-				"DL3023",
-				"DL3024",
-				"DL3025",
-				"DL4000",
-				"DL4001",
-				"DL4003",
-				"DL4005",
-				"DL4006",
-			},
-		},
-	}
-
-	for i, tc := range cases {
-		rst := getMakeDiff(tc.rules, tc.ignoreRules)
-		if !sliceEq(tc.expectedRst, rst) {
-			t.Errorf("#%d results deep equal has returned: want %s, got %s", i, tc.expectedRst, rst)
-		}
-		cleanup(t)
-	}
-}
-
-func cleanup(t *testing.T) {
-	t.Helper()
-}
-
-// reflect.DeepEqual(gotRst, gotRst)
-func sliceEq(a, b []string) bool {
-	// If one is nil, the other must also be nil.
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/linter/rules/dl3000.go
+++ b/linter/rules/dl3000.go
@@ -7,13 +7,13 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 )
 
-// validateDL3000 is "Use absolute WORKDIR."
+// validateDL3000 validates "Use absolute WORKDIR".
 func validateDL3000(node *parser.Node, _ *RuleOptions) (rst []ValidateResult, err error) {
 	for _, child := range node.Children {
 		if child.Value == WORKDIR {
 			absPath, err := filepath.Abs(child.Next.Value)
 			if err != nil {
-				return nil, fmt.Errorf("#%v DL3000: failed to convert relative path to absolute path (err: %s)", child.StartLine, err)
+				return nil, fmt.Errorf("#%v DL3000: failed to convert relative path to absolute path: %w", child.StartLine, err)
 			}
 			if absPath != child.Next.Value {
 				rst = append(rst, ValidateResult{line: child.StartLine})

--- a/linter/rules/dl3001.go
+++ b/linter/rules/dl3001.go
@@ -1,31 +1,27 @@
 package rules
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 )
 
-// validateDL3001 is "For some bash commands it makes no sense running them in a Docker container
-// like free, ifconfig, kill, mount, ps, service, shutdown, ssh, top, vim"
+// unsupportedTools is a list of commands that make no sense in a Docker container.
+var unsupportedTools = []string{"free", "ifconfig", "kill", "mount", "ps", "service", "shutdown", "ssh", "top", "vim"}
+
+// validateDL3001 validates that certain bash commands are not used in Docker containers.
+// Commands like free, ifconfig, kill, mount, ps, service, shutdown, ssh, top, vim
+// make no sense running in a Docker container.
 func validateDL3001(node *parser.Node, _ *RuleOptions) (rst []ValidateResult, err error) {
 	for _, child := range node.Children {
 		if child.Value == RUN {
 			for _, v := range strings.Fields(child.Next.Value) {
-				if existsTools(v) {
+				if slices.Contains(unsupportedTools, v) {
 					rst = append(rst, ValidateResult{line: child.StartLine})
 				}
 			}
 		}
 	}
 	return rst, nil
-}
-
-func existsTools(s string) bool {
-	for _, c := range []string{"free", "ifconfig", "kill", "mount", "ps", "service", "shutdown", "ssh", "top", "vim"} {
-		if s == c {
-			return true
-		}
-	}
-	return false
 }

--- a/linter/rules/dl3003.go
+++ b/linter/rules/dl3003.go
@@ -6,15 +6,14 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 )
 
-// validateDL3003 is "Use WORKDIR to switch to a directory"
+// validateDL3003 validates "Use WORKDIR to switch to a directory".
+// It checks if the first command in a RUN instruction is "cd".
 func validateDL3003(node *parser.Node, _ *RuleOptions) (rst []ValidateResult, err error) {
 	for _, child := range node.Children {
 		if child.Value == RUN {
-			for _, v := range strings.Fields(child.Next.Value) {
-				if v == "cd" {
-					rst = append(rst, ValidateResult{line: child.StartLine})
-				}
-				break
+			fields := strings.Fields(child.Next.Value)
+			if len(fields) > 0 && fields[0] == "cd" {
+				rst = append(rst, ValidateResult{line: child.StartLine})
 			}
 		}
 	}

--- a/linter/rules/dl3004.go
+++ b/linter/rules/dl3004.go
@@ -6,15 +6,14 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 )
 
-// validateDL3004 is "Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root."
+// validateDL3004 validates "Do not use sudo as it leads to unpredictable behavior".
+// It checks if the first command in a RUN instruction is "sudo".
 func validateDL3004(node *parser.Node, _ *RuleOptions) (rst []ValidateResult, err error) {
 	for _, child := range node.Children {
 		if child.Value == RUN {
-			for _, v := range strings.Fields(child.Next.Value) {
-				if v == "sudo" {
-					rst = append(rst, ValidateResult{line: child.StartLine})
-				}
-				break
+			fields := strings.Fields(child.Next.Value)
+			if len(fields) > 0 && fields[0] == "sudo" {
+				rst = append(rst, ValidateResult{line: child.StartLine})
 			}
 		}
 	}

--- a/linter/rules/dl3011.go
+++ b/linter/rules/dl3011.go
@@ -7,7 +7,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 )
 
-// validateDL3011 Valid UNIX ports range from 0 to 65535
+// validateDL3011 validates "Valid UNIX ports range from 0 to 65535".
 func validateDL3011(node *parser.Node, _ *RuleOptions) (rst []ValidateResult, err error) {
 	for _, child := range node.Children {
 		if child.Value == EXPOSE {
@@ -15,7 +15,7 @@ func validateDL3011(node *parser.Node, _ *RuleOptions) (rst []ValidateResult, er
 			if port != nil {
 				portNum, err := strconv.Atoi(port.Value)
 				if err != nil {
-					return nil, fmt.Errorf("#%v DL3011 not numeric is the value set for the port: %s", child.StartLine, port.Value)
+					return nil, fmt.Errorf("#%v DL3011: not numeric value for port %q: %w", child.StartLine, port.Value, err)
 				}
 				if portNum < 0 || portNum > 65535 {
 					rst = append(rst, ValidateResult{line: child.StartLine})

--- a/linter/rules/dl3011_test.go
+++ b/linter/rules/dl3011_test.go
@@ -26,7 +26,7 @@ EXPOSE 80000
 EXPOSE hoge
 `,
 			expectedRst: nil,
-			expectedErr: fmt.Errorf("#3 DL3011 not numeric is the value set for the port: hoge"),
+			expectedErr: fmt.Errorf("#3 DL3011: not numeric value for port \"hoge\": strconv.Atoi: parsing \"hoge\": invalid syntax"),
 		},
 	}
 

--- a/linter/rules/rule.go
+++ b/linter/rules/rule.go
@@ -297,17 +297,7 @@ var Rules = map[string]*Rule{
 	},
 }
 
-// isContain is a function to check if s is in xs
-func isContain(s []string, e string) bool {
-	for _, v := range s {
-		if e == v {
-			return true
-		}
-	}
-	return false
-}
-
-// CreateMessage : create output message
+// CreateMessage creates output messages from validation results.
 func CreateMessage(rule *Rule, vrst []ValidateResult) []string {
 	rst := make([]string, len(vrst))
 	for i, v := range vrst {


### PR DESCRIPTION
## Summary

- Replace custom helper functions (isContain, makeDiff, sliceEq) with standard library equivalents from the slices package
- Simplify concurrent analyzer to sequential processing for better readability
- Improve test structure using t.Run() subtests for better test isolation
- Fix missing file close and improve error message formatting
- Update documentation to reflect modern Go practices (go install, go mod download, Conventional Commits)

## Test Plan

- Run `go test ./...` to verify all tests pass
- Run `go build ./...` to verify the build succeeds

🤖 Generated with Claude Code