### PR TITLE
chore(renovate): disable dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    ":dependencyDashboard"
+    "config:recommended"
   ],
   "schedule": ["on sunday"],
   "automerge": true,


### PR DESCRIPTION
Removes the `:dependencyDashboard` preset from Renovate configuration to keep the issue tracker clean. The automerge feature is already enabled, so dependency updates will continue to happen automatically without the dashboard.

This will allow Issue #28 to be automatically closed by Renovate on the next run.

🤖 Generated with Claude Code