### PR TITLE
chore(renovate): disable dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "dependencyDashboard": false,
   "schedule": ["on sunday"],
   "automerge": true,
   "automergeType": "pr",


### PR DESCRIPTION
Disables the Renovate Dependency Dashboard to reduce noise from automated dependency management issues.

This prevents the creation of issue #28 and similar dashboard summary issues on future Renovate runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)